### PR TITLE
Add custom frontmatter property settings for date sorting

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -120,6 +120,8 @@ Date: {{ date }}
 `,
   excludeTags: [],
   dateFormat: 'YYYY-MM-DD',
+  useCustomChangedAtProperty: false,
+  customChangedAtProperty: 'created_at',
 };
 
 export default class VoiceNotesPlugin extends Plugin {
@@ -225,7 +227,11 @@ export default class VoiceNotesPlugin extends Plugin {
   }
 
   async isRecordingFromToday(file: TFile): Promise<boolean> {
-    return isToday(await this.app.metadataCache.getFileCache(file)?.frontmatter?.['created_at']);
+    return isToday(
+      await this.app.metadataCache.getFileCache(file)?.frontmatter?.[
+        this.settings.useCustomChangedAtProperty ? this.settings.customChangedAtProperty : 'created_at'
+      ]
+    );
   }
 
   sanitizedTitle(title: string, created_at: string): string {
@@ -407,10 +413,12 @@ export default class VoiceNotesPlugin extends Plugin {
         note = convertHtmlToMarkdown(note);
 
         // Recording ID is required so we force it
-        let recordingIdTemplate = `recording_id: {{recording_id}}\n`;
-        let renderedFrontmatter = jinja.render(recordingIdTemplate + this.settings.frontmatterTemplate, context).replace(/\n{3,}/g, '\n\n');
+        const recordingIdTemplate = `recording_id: {{recording_id}}\n`;
+        const renderedFrontmatter = jinja
+          .render(recordingIdTemplate + this.settings.frontmatterTemplate, context)
+          .replace(/\n{3,}/g, '\n\n');
 
-        const metadata = `---\n${renderedFrontmatter}\n---\n`
+        const metadata = `---\n${renderedFrontmatter}\n---\n`;
 
         note = metadata + note;
 
@@ -447,7 +455,7 @@ export default class VoiceNotesPlugin extends Plugin {
         await this.saveSettings();
         new Notice(`Login token was invalid, please try logging in again.`);
       } else {
-        new Notice(`Error occurred syncing some notes to this vault.`)
+        new Notice(`Error occurred syncing some notes to this vault.`);
       }
     }
   }
@@ -502,7 +510,7 @@ export default class VoiceNotesPlugin extends Plugin {
         await this.saveSettings();
         new Notice(`Login token was invalid, please try logging in again.`);
       } else {
-        new Notice(`Error occurred syncing some notes to this vault.`)
+        new Notice(`Error occurred syncing some notes to this vault.`);
       }
     }
   }

--- a/settings.ts
+++ b/settings.ts
@@ -1,7 +1,7 @@
 import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
-import VoiceNotesApi from './voicenotes-api';
 import VoiceNotesPlugin from './main';
 import { autoResizeTextArea } from './utils';
+import VoiceNotesApi from './voicenotes-api';
 
 export class VoiceNotesSettingTab extends PluginSettingTab {
   plugin: VoiceNotesPlugin;
@@ -258,7 +258,7 @@ export class VoiceNotesSettingTab extends PluginSettingTab {
         autoResizeTextArea(text.inputEl);
         text.inputEl.addEventListener('input', () => autoResizeTextArea(text.inputEl));
         containerEl.appendChild(text.inputEl);
-      })
+      });
 
     new Setting(containerEl)
       .setName('Note Template')
@@ -278,7 +278,31 @@ export class VoiceNotesSettingTab extends PluginSettingTab {
         autoResizeTextArea(text.inputEl);
         text.inputEl.addEventListener('input', () => autoResizeTextArea(text.inputEl));
         containerEl.appendChild(text.inputEl);
-      })
+      });
+
+    new Setting(containerEl)
+      .setName('Use custom frontmatter property for date sorting')
+      .setDesc(
+        'If you have changed the frontmatter template above, you can specify here which property should be used, e.g. to include todays notes.'
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.useCustomChangedAtProperty || false).onChange(async (value) => {
+          this.plugin.settings.useCustomChangedAtProperty = value;
+          await this.plugin.saveSettings();
+          await this.display(); // Refresh to update disabled state
+        })
+      )
+      .addText((text) => {
+        text
+          .setPlaceholder('Custom setting value')
+          .setValue(this.plugin.settings.customChangedAtProperty || '')
+          .setDisabled(!this.plugin.settings.useCustomChangedAtProperty)
+          .onChange(async (value) => {
+            this.plugin.settings.customChangedAtProperty = value;
+            await this.plugin.saveSettings();
+          });
+        return text;
+      });
 
     new Setting(containerEl)
       .setName('Exclude Tags')

--- a/types.ts
+++ b/types.ts
@@ -20,6 +20,8 @@ export interface VoiceNotesPluginSettings {
   filenameTemplate: string;
   excludeTags: string[];
   dateFormat: string;
+  useCustomChangedAtProperty: boolean;
+  customChangedAtProperty: string;
 }
 
 export interface UserSettings {


### PR DESCRIPTION
Introduce options for using a custom frontmatter property for date sorting, allowing users to specify which property should be utilized for determining today's notes.

I changed the default frontmatter template, and therefore the original logic using the `changed_at` property to determine which are todays notes is not working for me.