### PR TITLE
Use recording title for the Note template instead of the filename

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -363,7 +363,7 @@ export default class VoiceNotesPlugin extends Plugin {
             : null;
         const context = {
           recording_id: recording.recording_id,
-          title: title,
+          title: recording.title,
           date: formatDate(recording.created_at, this.settings.dateFormat),
           duration: formatDuration(recording.duration),
           created_at: formatDate(recording.created_at, this.settings.dateFormat),


### PR DESCRIPTION
The file name has been sanitized and had the date prepended to it, so this allows the original title to be used in the note, without having the date added to it.

Fixes #79 