### PR TITLE
Fix request body not being passed in makeAuthenticatedRequest

### DIFF
--- a/src/api/voicenotes.ts
+++ b/src/api/voicenotes.ts
@@ -82,6 +82,7 @@ export default class VoiceNotesApi {
     const fetchOptions: RequestInit = {
       method: options.method || 'GET',
       headers,
+      body: options.body,
     };
 
     const res = await fetch(url, fetchOptions);


### PR DESCRIPTION
This pull request resolves an issue where subsequent syncs would re-sync all data because request parameters weren't being passed to the API

**Summary of Changes**

- Fixed makeAuthenticatedRequest to include the body property in fetch options, ensuring POST parameters like last_synced_note_updated_at are sent to the API

**Testing & Validation**

Manual testing with Obsidian confirmed:

- Verified subsequent syncs only fetch new/updated recordings instead of all data

- Verified last_synced_note_updated_at and obsidian_deleted_recording_ids are received by the API

